### PR TITLE
These endpoints are no longer public

### DIFF
--- a/Fundamentals.md
+++ b/Fundamentals.md
@@ -9,7 +9,7 @@
 
 | URI                                      | HTTP Method | Authentication |
 |------------------------------------------|-------------|----------------|
-| api.robinhood.com/fundamentals/{symbol}/ | GET         | No             |
+| api.robinhood.com/fundamentals/{symbol}/ | GET         | YES            |
 
 **Fields**
 
@@ -69,7 +69,7 @@ You can gather data for a list of symbols at once by handing the bare `/fundamen
 
 | URI                            | HTTP Method | Authentication |
 |--------------------------------|-------------|----------------|
-| api.robinhood.com/fundamentals/ | GET         | No             |
+| api.robinhood.com/fundamentals/ | GET         | YES             |
 
 **Fields**
 


### PR DESCRIPTION
These endpoints now needs Bearer Authentication
These are probably server generated, but may have some dynamic visitor and request based elements
Validity of robinhood.com's Bearer Tokens are less than an hour, as observed.